### PR TITLE
fix: accurately report score

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         $('#submit').click(function() {
             var check_list = document.querySelectorAll('input[type="checkbox"]:checked');
             var check_total = check_list.length;
-            $('#score').html("score: " + check_total + "/100");
+            $('#score').html("score: " + (100 - check_total) + "/100");
             $("#show").show();
             $("#hide").hide();
         });


### PR DESCRIPTION
Purity test scores are recorded by subtracting the amount of completed activities from the total amount. This is represented with `100 - check_total` not `check_total`.